### PR TITLE
feat: add pip-installable cpybuild CLI tool for Python-to-C builds

### DIFF
--- a/cpybuild
+++ b/cpybuild
@@ -1,0 +1,5 @@
+#!/usr/bin/env python3
+from src.cpybuild.cli import main
+
+if __name__ == "__main__":
+    main()

--- a/cpybuild.yaml
+++ b/cpybuild.yaml
@@ -1,0 +1,3 @@
+sources:
+  - src/**/*.py
+output: build/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pyyaml
+cython
+setuptools
+wheel

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="cpybuild",
+    version="0.1.0",
+    description="A Python build tool to transpile Python code to C using Cython.",
+    author="jayendra1107",
+    packages=find_packages(where="src"),
+    package_dir={"": "src"},
+    install_requires=[
+        "pyyaml",
+        "cython",
+        "setuptools",
+        "wheel"
+    ],
+    entry_points={
+        "console_scripts": [
+            "cpybuild=cpybuild.cli:main"
+        ]
+    },
+    include_package_data=True,
+    python_requires=">=3.7",
+)

--- a/src/cpybuild/__init__.py
+++ b/src/cpybuild/__init__.py
@@ -1,0 +1,1 @@
+# cpybuild package

--- a/src/cpybuild/cli.py
+++ b/src/cpybuild/cli.py
@@ -1,0 +1,16 @@
+import argparse
+from .core import run_task
+
+def main():
+    import os
+    parser = argparse.ArgumentParser(prog='cpybuild', description='Python-to-C build tool')
+    parser.add_argument('command', choices=['init', 'build', 'clean', 'test'], help='Command to run')
+    args = parser.parse_args()
+    # Ensure we are in the project root (where cpybuild.yaml exists), except for init
+    if args.command != 'init' and not os.path.exists('cpybuild.yaml'):
+        print('Error: cpybuild.yaml not found. Please run this command from your project root directory.')
+        exit(1)
+    run_task(args.command)
+
+if __name__ == '__main__':
+    main()

--- a/src/cpybuild/core.py
+++ b/src/cpybuild/core.py
@@ -1,0 +1,16 @@
+import os
+import sys
+from .tasks import build, clean, init, test
+
+def run_task(task_name):
+    if task_name == 'build':
+        build.run()
+    elif task_name == 'clean':
+        clean.run()
+    elif task_name == 'init':
+        init.run()
+    elif task_name == 'test':
+        test.run()
+    else:
+        print(f'Unknown task: {task_name}')
+        sys.exit(1)

--- a/src/cpybuild/tasks/__init__.py
+++ b/src/cpybuild/tasks/__init__.py
@@ -1,0 +1,1 @@
+# Task modules for cpybuild

--- a/src/cpybuild/tasks/build.py
+++ b/src/cpybuild/tasks/build.py
@@ -1,0 +1,44 @@
+def run() -> None:
+    """
+    Build task: Transpile Python files to C using Cython and setuptools.
+    Collects all source files, creates Extension objects, and calls cythonize once.
+    """
+    import yaml
+    import glob
+    import os
+    from Cython.Build import cythonize
+    from setuptools import Extension
+
+    print('Building project (Python to C)...')
+    # Load config
+    with open('cpybuild.yaml') as f:
+        config = yaml.safe_load(f)
+    sources: list[str] = []
+    for pattern in config.get('sources', []):
+        sources.extend(glob.glob(pattern, recursive=True))
+    import sys
+    output_dir: str = os.environ.get('CPYBUILD_LOC', config.get('output', 'build/'))
+    os.makedirs(output_dir, exist_ok=True)
+    # Add output_dir to sys.path for importing built modules
+    if output_dir not in sys.path:
+        sys.path.insert(0, output_dir)
+
+    extensions: list[Extension] = []
+    for src in sources:
+        print(f'Transpiling {src}...')
+        module_name = os.path.splitext(os.path.relpath(src, start="src").replace(os.sep, "."))[0]
+        extensions.append(Extension(
+            name=module_name,
+            sources=[src],
+        ))
+
+    if extensions:
+        cythonize(
+            extensions,
+            compiler_directives={'language_level': 3},
+            build_dir=output_dir,
+            annotate=False
+        )
+        print(f'All sources transpiled to C in {output_dir}')
+    else:
+        print('No source files found to transpile.')

--- a/src/cpybuild/tasks/clean.py
+++ b/src/cpybuild/tasks/clean.py
@@ -1,0 +1,10 @@
+import shutil
+import os
+
+def run():
+    print('Cleaning build artifacts...')
+    if os.path.exists('build'):
+        shutil.rmtree('build')
+        print('Removed build directory.')
+    else:
+        print('No build directory found.')

--- a/src/cpybuild/tasks/init.py
+++ b/src/cpybuild/tasks/init.py
@@ -1,0 +1,6 @@
+def run():
+    print('Initializing cpybuild project...')
+    config = 'sources:\n  - src/**/*.py\noutput: build/'
+    with open('cpybuild.yaml', 'w') as f:
+        f.write(config)
+    print('Created cpybuild.yaml')

--- a/src/cpybuild/tasks/test.py
+++ b/src/cpybuild/tasks/test.py
@@ -1,0 +1,20 @@
+def run() -> None:
+    """
+    Discover and run all unittests in the 'tests' directory.
+    Looks for files matching 'test_*.py' and executes them using unittest.
+    """
+    import unittest
+    import glob
+    print('Discovering and running tests...')
+    test_files: list[str] = glob.glob('tests/test_*.py')
+    if not test_files:
+        print('No test files found in tests/.')
+        return
+    loader: unittest.TestLoader = unittest.TestLoader()
+    suite: unittest.TestSuite = loader.discover('tests', pattern='test_*.py')
+    runner: unittest.TextTestRunner = unittest.TextTestRunner(verbosity=2)
+    result: unittest.runner.TextTestResult = runner.run(suite)
+    if result.wasSuccessful():
+        print('All tests passed!')
+    else:
+        print('Some tests failed.')


### PR DESCRIPTION
- Implement CLI with commands: init, build, clean, test
- Add Cython-based build logic with support for CPYBUILD_LOC env variable
- Ensure CLI only runs from project root (with cpybuild.yaml)
- Add setuptools/pyproject.toml for pip install and console_scripts entry point
- Improve test and build tasks with docstrings and type hints